### PR TITLE
Accept certificate authority optionally from a file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ARG KUBERNETES_VERSION=
 
 RUN set -x && \
     apt-get update && \
-    apt-get install -y jq curl && \
+    apt-get install -y jq curl gettext-base && \
     [ -z "$KUBERNETES_VERSION" ] && KUBERNETES_VERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt) ||: && \
     curl -s -LO https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/linux/amd64/kubectl && \
     chmod +x ./kubectl && \

--- a/README.md
+++ b/README.md
@@ -34,12 +34,16 @@ The version of this resource corresponds to the version of kubectl. We recommend
 - `server`: *Optional.* The address and port of the API server.
 - `token`: *Optional.* Bearer token for authentication to the API server.
 - `namespace`: *Optional.* The namespace scope. Defaults to `default`. If set along with `kubeconfig`, `namespace` will override the namespace in the current-context
-- `certificate_authority`: *Optional.* A certificate file for the certificate authority.
+- `certificate_authority`: *Optional.* A certificate for the certificate authority.
     ```yaml
     certificate_authority: |
         -----BEGIN CERTIFICATE-----
         ...
         -----END CERTIFICATE-----
+    ```
+- `certificate_authority_file`: *Optional.* A file to read the certificate from.
+    ```yaml
+    certificate_authority_file: ca_certs.crt
     ```
 - `insecure_skip_tls_verify`: *Optional.* If true, the API server's certificate will not be checked for validity. This will make your HTTPS connections insecure. Defaults to `false`.
 - `use_aws_iam_authenticator`: *Optional.* If true, the aws_iam_authenticator, required for connecting with EKS, is used. Requires `aws_eks_cluster_name`. Defaults to `false`.

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -41,13 +41,22 @@ setup_kubectl() {
     # Optional. The address and port of the API server. Requires token.
     local server
     server="$(jq -r '.source.server // ""' < "$payload")"
-    # Optional. A certificate file for the certificate authority.
+    # Optional. A file to read the certificate from.
+    local certificate_authority_file
+    certificate_authority_file="$(jq -r '.source.certificate_authority_file // ""' < "$payload")"
+    # Optional. A certificate for the certificate authority.
     local certificate_authority
-    certificate_authority="$(jq -r '.source.certificate_authority // ""' < "$payload")"
+    certificate_authority="$(jq -r '.source.certificate_authority // "${CERTIFICATE_AUTHORITY_FILE_CONTENTS}"' < "$payload")"
     # Optional. If true, the API server's certificate will not be checked for
     # validity. This will make your HTTPS connections insecure. Defaults to false.
     local insecure_skip_tls_verify
     insecure_skip_tls_verify="$(jq -r '.source.insecure_skip_tls_verify // ""' < "$payload")"
+
+    # When not set, try to get certificate_authority from a file, if provided
+    export CERTIFICATE_AUTHORITY_FILE_CONTENTS=""
+    [[ -n "${certificate_authority_file}" && ! -f "${certificate_authority_file}" ]] && certificate_authority_file=""
+    [[ -n "${certificate_authority_file}" && -f "${certificate_authority_file}" ]] && CERTIFICATE_AUTHORITY_FILE_CONTENTS="$(cat "${certificate_authority_file}")"
+    certificate_authority=$(echo "$certificate_authority" | envsubst)
 
     # Build options for kubectl config set-cluster
     local set_cluster_opts


### PR DESCRIPTION
Add an additional source param called `certificate_authority_file` for a user to be able to provide the certificate authority from a file.

This solves e.g., the usecase where the certificate authority might be base64 encoded. With this the base64 decoding can be delegated to a task.

See: zlabjp/kubernetes-resource#57